### PR TITLE
don't use -tt option on SSH command

### DIFF
--- a/src/pkg/target/target.go
+++ b/src/pkg/target/target.go
@@ -87,9 +87,9 @@ func (t *RemoteTarget) getSSHFlags(scp bool) (flags []string) {
 		"-o",
 		"ControlPersist=1m",
 	}
-	if scp == false {
-		flags = append(flags, "-tt")
-	}
+	// if scp == false {
+	// 	flags = append(flags, "-tt")
+	// }
 	if t.key != "" {
 		keyFlags := []string{
 			"-o",


### PR DESCRIPTION
-tt option might be causing error in some environments:
         process_mux_new_session: tcgetattr: Inappropriate ioctl for device

